### PR TITLE
don't parse use_https twice.

### DIFF
--- a/blockstore/lib/config.py
+++ b/blockstore/lib/config.py
@@ -621,8 +621,6 @@ def default_bitcoind_utxo_opts( config_file=None ):
                 use_https = True
             else:
                 use_https = False
-                
-            use_https = bool( parser.get("bitcoind_utxo", "use_https") )
            
        if parser.has_option("bitcoind_utxo", "version_byte"):
            version_byte = int(parser.get("bitcoind_utxo", "version_byte"))


### PR DESCRIPTION
I have use_https=False in my configuration, but blockstored still uses SSL sometimes. this seems to fix it.