### PR TITLE
Update link in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pip install blockstore
 ```
 
 If you encounter any problems during the pip install, see the [detailed install
-instructions](https://github.com/blockstack/blockstore/wiki/Usage).
+instructions](https://github.com/blockstack/blockstore/wiki/Installation).
 
 ## Getting started
 


### PR DESCRIPTION
Noticed error in link for detailed install instructions `https://github.com/blockstack/blockstore/wiki/Usage` to `https://github.com/blockstack/blockstore/wiki/Installation`